### PR TITLE
adds missing folder reference to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,4 +15,4 @@ jobs:
       - setup_remote_docker
       - run:
           name: "Build Docker Image"
-          command: docker build
+          command: docker build .


### PR DESCRIPTION
FYI @forgondolin, feel free to check this PR. When you do docker-build it needs a folder to be specified, which is that `.` - current folder.

It is NOT a criticism it is super easy to miss, but I figured might be good to share:)